### PR TITLE
feat: covid progress chart component

### DIFF
--- a/src/app/adapter/chart-adapter.service.ts
+++ b/src/app/adapter/chart-adapter.service.ts
@@ -3,7 +3,7 @@ import { map } from 'rxjs/operators';
 
 import { Covid19APIService } from '../api/covid19-api.service';
 import { Country } from '../models/covidAPI.model';
-import { SingleSeries, MultiSeries } from '@swimlane/ngx-charts';
+import { MultiSeries, SingleSeries } from '@swimlane/ngx-charts';
 import { Observable } from 'rxjs';
 
 @Injectable({

--- a/src/app/adapter/chart-adapter.service.ts
+++ b/src/app/adapter/chart-adapter.service.ts
@@ -25,8 +25,8 @@ export class ChartAdapterService {
   }
 
   getProgressInMexico(): Observable<MultiSeries> {
-    const to = this.getTodaysDate();
-    const from = this.getLastMonthsDate();
+    const to = this.getTodaysDateISO();
+    const from = this.getLastMonthsDateISO();
 
     return this.covidAPI
       .getByCountryAllStatus('mexico', from, to)
@@ -43,23 +43,25 @@ export class ChartAdapterService {
       Deaths: dValue,
       Recovered: rValue,
     } = item;
-    const [confirmed, deaths, recovered] = state;
+    const [confirmed, recovered, deaths] = state;
 
-    confirmed.series.push({ name: date, value: cValue });
-    deaths.series.push({ name: date, value: dValue });
-    recovered.series.push({ name: date, value: rValue });
+    const formattedDate = new Date(date).toLocaleDateString();
+
+    confirmed.series.push({ name: formattedDate, value: cValue });
+    deaths.series.push({ name: formattedDate, value: dValue });
+    recovered.series.push({ name: formattedDate, value: rValue });
 
     return state;
   }
 
-  private getTodaysDate(): string {
+  private getTodaysDateISO(): string {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
     return today.toISOString().split('.')[0] + 'Z';
   }
 
-  private getLastMonthsDate(): string {
+  private getLastMonthsDateISO(): string {
     const today = new Date();
     const lastMonth = new Date();
 
@@ -95,11 +97,11 @@ export class ChartAdapterService {
         series: [],
       },
       {
-        name: 'Deaths',
+        name: 'Recovered',
         series: [],
       },
       {
-        name: 'Recovered',
+        name: 'Deaths',
         series: [],
       },
     ];

--- a/src/app/adapter/chart-adapter.service.ts
+++ b/src/app/adapter/chart-adapter.service.ts
@@ -3,7 +3,7 @@ import { map } from 'rxjs/operators';
 
 import { Covid19APIService } from '../api/covid19-api.service';
 import { Country } from '../models/covidAPI.model';
-import { SingleSeries } from '@swimlane/ngx-charts';
+import { SingleSeries, MultiSeries } from '@swimlane/ngx-charts';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -24,6 +24,51 @@ export class ChartAdapterService {
     );
   }
 
+  getProgressInMexico(): Observable<MultiSeries> {
+    const to = this.getTodaysDate();
+    const from = this.getLastMonthsDate();
+
+    return this.covidAPI
+      .getByCountryAllStatus('mexico', from, to)
+      .pipe(
+        map((list) =>
+          list.reduce(this.transformToChartData, this.getProgressInitialState())
+        )
+      );
+  }
+  private transformToChartData(state: MultiSeries, item: Country): MultiSeries {
+    const {
+      Confirmed: cValue,
+      Date: date,
+      Deaths: dValue,
+      Recovered: rValue,
+    } = item;
+    const [confirmed, deaths, recovered] = state;
+
+    confirmed.series.push({ name: date, value: cValue });
+    deaths.series.push({ name: date, value: dValue });
+    recovered.series.push({ name: date, value: rValue });
+
+    return state;
+  }
+
+  private getTodaysDate(): string {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    return today.toISOString().split('.')[0] + 'Z';
+  }
+
+  private getLastMonthsDate(): string {
+    const today = new Date();
+    const lastMonth = new Date();
+
+    lastMonth.setMonth(today.getMonth() - 1);
+    lastMonth.setHours(0, 0, 0, 0);
+
+    return lastMonth.toISOString().split('.')[0] + 'Z';
+  }
+
   private getSingleSeries(country: Country, suffix: string): SingleSeries {
     const { TotalConfirmed, TotalDeaths, TotalRecovered } = country;
 
@@ -39,6 +84,23 @@ export class ChartAdapterService {
       {
         name: `Recovered (${suffix})`,
         value: TotalRecovered,
+      },
+    ];
+  }
+
+  private getProgressInitialState(): MultiSeries {
+    return [
+      {
+        name: 'Confirmed',
+        series: [],
+      },
+      {
+        name: 'Deaths',
+        series: [],
+      },
+      {
+        name: 'Recovered',
+        series: [],
       },
     ];
   }

--- a/src/app/api/covid19-api.service.ts
+++ b/src/app/api/covid19-api.service.ts
@@ -1,8 +1,8 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
 
-import { Summary } from '../models/covidAPI.model';
+import { Summary, Countries } from '../models/covidAPI.model';
 import { Observable } from 'rxjs';
 
 import { environment } from '../../environments/environment';
@@ -19,5 +19,13 @@ export class Covid19APIService {
     return this.http
       .get<Summary>(this.baseURL + 'summary')
       .pipe(map((summary) => summary));
+  }
+
+  getByCountryAllStatus(countrySlug, from, to): Observable<Countries> {
+    const params = new HttpParams().set('from', from).set('to', to);
+
+    return this.http
+      .get<Countries>(`${this.baseURL}/country/${countrySlug}`, { params })
+      .pipe(map((countries) => countries));
   }
 }

--- a/src/app/api/covid19-api.service.ts
+++ b/src/app/api/covid19-api.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { map } from 'rxjs/operators';
 
-import { Summary, Countries } from '../models/covidAPI.model';
+import { Countries, Summary } from '../models/covidAPI.model';
 import { Observable } from 'rxjs';
 
 import { environment } from '../../environments/environment';

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,6 +5,6 @@
 </mat-toolbar>
 <div class="wrapper">
   <section class="overall"><app-overall></app-overall></section>
-  <section class="lines">Lines</section>
+  <section class="lines"><app-progress></app-progress></section>
   <section class="bars">Bars</section>
 </div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,9 +9,10 @@ import { NumberCardModule } from '@swimlane/ngx-charts';
 
 import { AppComponent } from './app.component';
 import { OverallComponent } from './components/overall/overall.component';
+import { ProgressComponent } from './components/progress/progress.component';
 
 @NgModule({
-  declarations: [AppComponent, OverallComponent],
+  declarations: [AppComponent, OverallComponent, ProgressComponent],
   imports: [
     AppRoutingModule,
     BrowserAnimationsModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { MatCardModule } from '@angular/material/card';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { NgModule } from '@angular/core';
-import { NumberCardModule } from '@swimlane/ngx-charts';
+import { NgxChartsModule } from '@swimlane/ngx-charts';
 
 import { AppComponent } from './app.component';
 import { OverallComponent } from './components/overall/overall.component';
@@ -20,7 +20,7 @@ import { ProgressComponent } from './components/progress/progress.component';
     HttpClientModule,
     MatCardModule,
     MatToolbarModule,
-    NumberCardModule,
+    NgxChartsModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/components/progress/progress.component.html
+++ b/src/app/components/progress/progress.component.html
@@ -1,0 +1,4 @@
+<mat-card>
+  <mat-card-title>COVID progress in Mexico</mat-card-title>
+  <mat-card-content></mat-card-content>
+</mat-card>

--- a/src/app/components/progress/progress.component.html
+++ b/src/app/components/progress/progress.component.html
@@ -1,4 +1,22 @@
 <mat-card>
   <mat-card-title>COVID progress in Mexico</mat-card-title>
-  <mat-card-content></mat-card-content>
+  <mat-card-content>
+    <ngx-charts-area-chart
+      [legend]="legend"
+      legendTitle=""
+      [legendPosition]="legendPosition"
+      [results]="results$ | async"
+      [scheme]="scheme"
+      [showXAxisLabel]="showXAxisLabel"
+      [showYAxisLabel]="showYAxisLabel"
+      [timeline]="timeline"
+      [view]="view"
+      [xAxis]="xAxis"
+      [xAxisLabel]="xAxisLabel"
+      [yAxis]="yAxis"
+      [yAxisLabel]="yAxisLabel"
+      style="fill: #a0a8be;"
+    >
+    </ngx-charts-area-chart>
+  </mat-card-content>
 </mat-card>

--- a/src/app/components/progress/progress.component.spec.ts
+++ b/src/app/components/progress/progress.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProgressComponent } from './progress.component';
+
+describe('ProgressComponent', () => {
+  let component: ProgressComponent;
+  let fixture: ComponentFixture<ProgressComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ProgressComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProgressComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/progress/progress.component.ts
+++ b/src/app/components/progress/progress.component.ts
@@ -1,15 +1,33 @@
 import { Component, OnInit } from '@angular/core';
+import { ChartAdapterService } from 'src/app/adapter/chart-adapter.service';
+import { Observable } from 'rxjs';
+import { MultiSeries } from '@swimlane/ngx-charts';
 
 @Component({
   selector: 'app-progress',
   templateUrl: './progress.component.html',
-  styleUrls: ['./progress.component.styl']
+  styleUrls: ['./progress.component.styl'],
 })
 export class ProgressComponent implements OnInit {
+  // chart settings
+  animations: boolean = true;
+  legend: boolean = true;
+  legendPosition: string = 'below';
+  results$: Observable<MultiSeries>;
+  scheme = 'cool';
+  showLabels: boolean = true;
+  showXAxisLabel: boolean = true;
+  showYAxisLabel: boolean = true;
+  timeline: boolean = true;
+  view = [null, 400];
+  xAxis: boolean = true;
+  xAxisLabel: string = 'Last 30 Days';
+  yAxis: boolean = true;
+  yAxisLabel: string = 'Population';
 
-  constructor() { }
+  constructor(private chartAdapter: ChartAdapterService) {}
 
   ngOnInit(): void {
+    this.results$ = this.chartAdapter.getProgressInMexico();
   }
-
 }

--- a/src/app/components/progress/progress.component.ts
+++ b/src/app/components/progress/progress.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit } from '@angular/core';
 import { ChartAdapterService } from 'src/app/adapter/chart-adapter.service';
-import { Observable } from 'rxjs';
+import { Component, OnInit } from '@angular/core';
 import { MultiSeries } from '@swimlane/ngx-charts';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-progress',

--- a/src/app/components/progress/progress.component.ts
+++ b/src/app/components/progress/progress.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-progress',
+  templateUrl: './progress.component.html',
+  styleUrls: ['./progress.component.styl']
+})
+export class ProgressComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/models/covidAPI.model.ts
+++ b/src/app/models/covidAPI.model.ts
@@ -1,12 +1,23 @@
-export interface Country {
+export interface CountryBase {
   Country: string;
+  ISO2: string;
+  Slug: string;
+}
+export interface Country extends CountryBase {
+  Active?: number;
+  City?: string;
+  CityCode?: string;
+  Confirmed?: number;
   CountryCode?: string;
   Date?: string;
-  ISO2?: string;
+  Deaths?: number;
+  Lat?: string;
+  Lon?: string;
   NewConfirmed?: number;
   NewDeaths?: number;
   NewRecovered?: number;
-  Slug: string;
+  Province?: string;
+  Recovered?: number;
   TotalConfirmed?: number;
   TotalDeaths?: number;
   TotalRecovered?: number;


### PR DESCRIPTION
Show a chart displaying the progress of COVID in Mexico.

- add new endpoint
- transform response data into multi-series data for the chart
- configure and show the chart